### PR TITLE
fix of host without os information, utf8 file

### DIFF
--- a/tools/ovirt-inventory/generator.py
+++ b/tools/ovirt-inventory/generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import argparse
+import codecs
 import configparser
 import os
 import re
@@ -370,7 +371,7 @@ def main():
                 config['other']['output_dir'], "%s.yaml" % server
             )
 
-            with open(path, 'w') as file_out:
+            with codecs.open(path, 'w', 'UTF-8') as file_out:
                 result, error = _yaml.write_engine(data, file_out)
                 if result:
                     print('yaml file saved to %s' % file_out.name)

--- a/tools/ovirt-inventory/helpers/api.py
+++ b/tools/ovirt-inventory/helpers/api.py
@@ -163,11 +163,16 @@ class ApiData:
         hosts = []
         data_hosts = self.api.get('hosts')
         for host in data_hosts.get('host', []):
-            host['os_version'] = '{os_type}-{major_ver}.{minor_ver}'.format(
-                os_type=host['os']['type'],
-                major_ver=host['os']['version']['major'],
-                minor_ver=host['os']['version'].get('minor', 'x')
-            )
+            try:
+                host['os_version'] = (
+                    '{os_type}-{major_ver}.{minor_ver}'.format(
+                        os_type=host['os']['type'],
+                        major_ver=host['os']['version']['major'],
+                        minor_ver=host['os']['version'].get('minor', 'x')
+                    )
+                )
+            except KeyError:
+                host['os_version'] = ''
             data_cluster = self.api.get(
                 self.api.get_api_url_part(host['cluster']['href'])
             )


### PR DESCRIPTION
Fix defining os_version for host, when the information is not provided by the api.
Yaml file opened as utf8.